### PR TITLE
Add GitHub Actions workflow for build and deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Build & Deploy
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    outputs:
+        image: ${{ steps.vars.outputs.image }}
+        sha_image: ${{ steps.vars.outputs.sha_image }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Build
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          
+      # Compute lowercase GHCR image name
+      - name: Compute image name (lowercase)
+        id: vars
+        run: |
+          IMAGE="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "sha_image=$IMAGE:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & Push (cached)
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          tags: |
+            ${{ steps.vars.outputs.image }}:latest
+            ${{ steps.vars.outputs.sha_image }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
GitHub Actions Solution if anyone is looking for it!

**Deployment automation:**

* Adds a `.github/workflows/deploy.yml` workflow that builds and pushes Docker images to GHCR on every push to `main` or via manual trigger, using Docker Buildx for advanced build features and caching.

**Workflow improvements:**

* Implements concurrency control to prevent overlapping deployments for the same branch.
* Automatically computes and uses lowercase image names and tags images with both `latest` and commit SHA for traceability.
* Leverages GitHub Actions cache for Docker layers to speed up subsequent builds.